### PR TITLE
Fix/reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,15 @@ data/**/*
 data/
 node_modules/*/*
 node_modules/
+**/*.pyc
+**/*.eggs/
+**/*.egg-info/
+**/__pycache__/
+.cache/
+.idea/
+.git/
+.pytest_cache/
+tox.ini
+build/
+dist/
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ venv.bak/
 # mypy
 .mypy_cache/
 data
+
+# pycharm
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . /workspace
 # Install any needed packages
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash &&\
     apt-get update &&\
-	apt-get install -y --no-install-recommends vim less nodejs &&\
+    apt-get install -y --no-install-recommends vim less nodejs &&\
     rm -rf /var/lib/apt/lists/* &&\
 	curl -o- -L https://yarnpkg.com/install.sh | bash &&\
 	pip install --no-cache-dir --upgrade pip &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,20 @@ FROM pytorch/pytorch:0.4.1-cuda9-cudnn7-runtime
 # Set the working directory to /app
 WORKDIR /workspace
 
+# Add the data directory to the workspace
+VOLUME ["/workspace/data"] 
+
 # Copy the current directory contents into the container at /app
 COPY . /workspace
 
 # Install any needed packages
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash &&\
-	apt-get install -y vim less nodejs &&\
+    apt-get update &&\
+	apt-get install -y --no-install-recommends vim less nodejs &&\
+    rm -rf /var/lib/apt/lists/* &&\
 	curl -o- -L https://yarnpkg.com/install.sh | bash &&\
-	pip install --upgrade pip &&\
-	pip install --trusted-host pypi.python.org -r requirements.txt &&\
+	pip install --no-cache-dir --upgrade pip &&\
+	pip install --no-cache-dir --trusted-host pypi.python.org -r requirements.txt &&\
 	$HOME/.yarn/bin/yarn install
 
 # Make port 80 available to the world outside this container

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash &&\
     apt-get update &&\
     apt-get install -y --no-install-recommends vim less nodejs &&\
     rm -rf /var/lib/apt/lists/* &&\
-	curl -o- -L https://yarnpkg.com/install.sh | bash &&\
-	pip install --no-cache-dir --upgrade pip &&\
-	pip install --no-cache-dir --trusted-host pypi.python.org -r requirements.txt &&\
-	$HOME/.yarn/bin/yarn install
+    curl -o- -L https://yarnpkg.com/install.sh | bash &&\
+    pip install --no-cache-dir --upgrade pip &&\
+    pip install --no-cache-dir --trusted-host pypi.python.org -r requirements.txt &&\
+    $HOME/.yarn/bin/yarn install
 
 # Make port 80 available to the world outside this container
 EXPOSE 80


### PR DESCRIPTION
The aim of these changes is to reduce the final docker image size. The changes I've made so far reduce the size from 3.68 to 3.44 GB. 

A couple of other changes unrelated to image size:
- I added a `sudo apt-get update` command, which is recommended to do in [best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
- I added a `/workspace/data` volume, which I thought may be necessary to mount your local `/data` to `.data` (where the code expects to find it).